### PR TITLE
EP-3511

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -501,6 +501,9 @@ router.beforeEach(async (to, from, next) => {
       next();
     }
     catch (err) {
+      if (err.response.status === 404) {
+        router.push({ name: 'virhe' });
+      }
       throw new Error(err);
     }
   }

--- a/src/stores/kayttaja.ts
+++ b/src/stores/kayttaja.ts
@@ -2,8 +2,8 @@ import _ from 'lodash';
 import Vue from 'vue';
 import { Kayttajat as KayttajatApi, KayttajanTietoDto, Perusteprojektit } from '@shared/api/eperusteet';
 import { createLogger } from '@shared/utils/logger';
-import VueCompositionApi, { reactive, computed, ref, watch } from '@vue/composition-api';
-import { getSovellusoikeudet, IOikeusProvider, Oikeustarkastelu } from '@shared/plugins/oikeustarkastelu';
+import VueCompositionApi, { reactive, computed } from '@vue/composition-api';
+import { getSovellusoikeudet, IOikeusProvider } from '@shared/plugins/oikeustarkastelu';
 import { getCasKayttaja } from '@shared/api/common';
 
 Vue.use(VueCompositionApi);
@@ -91,6 +91,7 @@ export class KayttajaStore implements IOikeusProvider {
     }
     catch (err) {
       logger.error('Ei oikeuksia', err.message);
+      throw err;
     }
   }
 


### PR DESCRIPTION
Heitetään käyttäjäoikeuksien haun poikkeus jatkossa eteenpäin, koska tällä hetkellä se vaimennetaan kayttajastoressa. Siirretään 404-sivulle, mikäli responsesta löytyy tämä virhekoodi. 

Tällä tavalla ei pitäisi enää tulla enää myös 403-virhettä kun perustetta tai projektia ei löydy kun annetaan olematon id urliin.