### PR TITLE
EP-3611

### DIFF
--- a/src/views/RouteJulkaise.vue
+++ b/src/views/RouteJulkaise.vue
@@ -404,7 +404,7 @@ export default class RouteJulkaise extends Mixins(PerusteprojektiRoute, EpValida
     if (julkaisu.peruste && julkaisu.peruste.id) {
       return buildKatseluUrl(Kielet.getSisaltoKieli.value, `/${koulutustyyppiTheme(this.perusteStore.peruste.value!.koulutustyyppi!)}/${julkaisu.peruste.id}`, revision);
     }
-    return null;
+    return '';
   }
 }
 


### PR DESCRIPTION
Minifix urlin rakentamiseen. EpExternalLink vaatii url propin stringinä tilanteissa kun tehdään julkaisu ja julkaisulla ei ole vielä perusteen tietoja urlin rakentamista varten.